### PR TITLE
feat/inline mode

### DIFF
--- a/cmd/inline/caller.go
+++ b/cmd/inline/caller.go
@@ -1,0 +1,75 @@
+package inline
+
+import (
+	"fmt"
+	"github.com/IbraheemHaseeb7/apee-i/cmd"
+	"github.com/IbraheemHaseeb7/apee-i/cmd/protocols"
+	myHttp "github.com/IbraheemHaseeb7/apee-i/cmd/protocols/http"
+	"github.com/IbraheemHaseeb7/apee-i/utils"
+)
+
+type Options struct {
+	Method             string
+	Body               string
+	Endpoint           string
+	Headers            map[string]string
+	BaseURL            string
+	Protocol           string
+	Timeout            int
+	Token              string
+	ExpectedStatusCode int
+}
+
+func RunInline(opts Options) {
+	pipeline := *cmd.NewPipelineBody(&cmd.PipelineBody{
+		Method:             opts.Method,
+		Body:               opts.Body,
+		Endpoint:           opts.Endpoint,
+		Headers:            convertHeaders(opts.Headers),
+		BaseURL:            opts.BaseURL,
+		Protocol:           opts.Protocol,
+		Timeout:            opts.Timeout,
+		ExpectedStatusCode: opts.ExpectedStatusCode,
+	})
+
+	protocolContext := &protocols.ProtocolContext{}
+
+	if opts.Protocol == "HTTP" {
+		protocolContext.SetStrategy(&myHttp.Strategy{})
+	} else {
+		fmt.Println(utils.Red + "Invalid Protocol specified. Only HTTP is supported at this time" + opts.Protocol)
+		return
+	}
+
+	if opts.Token != "" {
+		if pipeline.Headers == nil {
+			pipeline.Headers = make(map[string]interface{})
+		}
+		pipeline.Headers["Authorization"] = "Bearer " + opts.Token
+	}
+
+	dummyConfig := &cmd.Structure{
+		ActiveURL: opts.BaseURL,
+		LoginDetails: cmd.LoginDetails{
+			Token: opts.Token,
+		},
+	}
+
+	res, err := protocolContext.Hit(dummyConfig, pipeline)
+
+	if err != nil {
+		fmt.Println(utils.Red + "Error executing inline call: " + err.Error() + utils.Reset)
+	}
+
+	fmt.Println("Response:")
+	fmt.Println(res.Body.StringIndent("", " "))
+}
+
+func convertHeaders(input map[string]string) map[string]any {
+	headers := make(map[string]any)
+	for k, v := range input {
+		headers[k] = v
+	}
+
+	return headers
+}

--- a/cmd/inline/caller.go
+++ b/cmd/inline/caller.go
@@ -8,6 +8,7 @@ import (
 	"github.com/IbraheemHaseeb7/apee-i/utils"
 )
 
+// Options contains the properties that define an inline request
 type Options struct {
 	Method             string
 	Body               string
@@ -20,6 +21,7 @@ type Options struct {
 	ExpectedStatusCode int
 }
 
+// RunInline function executes an inline request
 func RunInline(opts Options) {
 	pipeline := *cmd.NewPipelineBody(&cmd.PipelineBody{
 		Method:             opts.Method,

--- a/main.go
+++ b/main.go
@@ -74,6 +74,16 @@ func main() {
 
 	// inline mode
 	if *inlineMode {
+
+		if *inlineBaseURL == "" {
+			fmt.Println("Error: Base URL (--url) is required in inline mode.")
+			return
+		}
+		if *inlineEndpoint == "" {
+			fmt.Println("Error: Endpoint (--endpoint) is required in inline mode.")
+			return
+		}
+
 		headers := make(map[string]string)
 
 		if *inlineHeaders != "" {


### PR DESCRIPTION
This PR adds `inline` mode.

- API is kept very close to previously existing file based modes
- Only HTTP protocol is supported

Usage examples 
- `apee-i --inline --url="https://jsonplaceholder.typicode.com" --endpoint="/todos" --method="GET" --statusCode=200 --protocol="HTTP" --timeout=30`
- `apee-i --inline --url="https://jsonplaceholder.typicode.com" --endpoint="/todos"`