### PR TITLE
refactor: combine url and endpoint

### DIFF
--- a/cmd/inline/caller.go
+++ b/cmd/inline/caller.go
@@ -27,6 +27,7 @@ func RunInline(opts Options) {
 
 	if err != nil {
 		fmt.Println(utils.Red + "Error parsing the URL: " + err.Error() + utils.Reset)
+		return
 	}
 
 	baseURL := parsedURL.Scheme + "://" + parsedURL.Host
@@ -70,6 +71,7 @@ func RunInline(opts Options) {
 
 	if err != nil {
 		fmt.Println(utils.Red + "Error executing inline call: " + err.Error() + utils.Reset)
+		return
 	}
 
 	fmt.Println("Response:")

--- a/cmd/inline/caller.go
+++ b/cmd/inline/caller.go
@@ -6,15 +6,15 @@ import (
 	"github.com/IbraheemHaseeb7/apee-i/cmd/protocols"
 	myHttp "github.com/IbraheemHaseeb7/apee-i/cmd/protocols/http"
 	"github.com/IbraheemHaseeb7/apee-i/utils"
+	"net/url"
 )
 
 // Options contains the properties that define an inline request
 type Options struct {
 	Method             string
+	URL                string
 	Body               string
-	Endpoint           string
 	Headers            map[string]string
-	BaseURL            string
 	Protocol           string
 	Timeout            int
 	Token              string
@@ -23,12 +23,21 @@ type Options struct {
 
 // RunInline function executes an inline request
 func RunInline(opts Options) {
+	parsedURL, err := url.Parse(opts.URL)
+
+	if err != nil {
+		fmt.Println(utils.Red + "Error parsing the URL: " + err.Error() + utils.Reset)
+	}
+
+	baseURL := parsedURL.Scheme + "://" + parsedURL.Host
+	endpoint := parsedURL.Path
+
 	pipeline := *cmd.NewPipelineBody(&cmd.PipelineBody{
 		Method:             opts.Method,
 		Body:               opts.Body,
-		Endpoint:           opts.Endpoint,
+		Endpoint:           endpoint,
 		Headers:            convertHeaders(opts.Headers),
-		BaseURL:            opts.BaseURL,
+		BaseURL:            baseURL,
 		Protocol:           opts.Protocol,
 		Timeout:            opts.Timeout,
 		ExpectedStatusCode: opts.ExpectedStatusCode,
@@ -51,7 +60,7 @@ func RunInline(opts Options) {
 	}
 
 	dummyConfig := &cmd.Structure{
-		ActiveURL: opts.BaseURL,
+		ActiveURL: baseURL,
 		LoginDetails: cmd.LoginDetails{
 			Token: opts.Token,
 		},

--- a/main.go
+++ b/main.go
@@ -62,9 +62,8 @@ func main() {
 	inlineMode := flag.Bool("inline", false, "Run in inline mode (ignores configuration file)")
 	inlineMethod := flag.String("method", "GET", "HTTP method for inline mode (e.g., GET, POST, PUT, DELETE)")
 	inlineBody := flag.String("body", "", "Request body as a JSON string for inline mode")
-	inlineEndpoint := flag.String("endpoint", "", "Endpoint for inline mode (e.g., v1/users)")
+	inlineURL := flag.String("url", "", "URL for inline mode (e.g., https://api.example.com/v1/users)")
 	inlineHeaders := flag.String("headers", "", "Custom header(s) in key:value format (comma-separated, e.g., 'Content-Type:application/json,Accept:application/json')")
-	inlineBaseURL := flag.String("url", "", "Base URL for inline mode (e.g., https://api.example.com)")
 	inlineProtocol := flag.String("protocol", "HTTP", "Protocol to use for inline mode (currently only HTTP is supported)")
 	inlineTimeout := flag.Int("timeout", 30, "Request timeout in seconds for inline mode")
 	inlineToken := flag.String("token", "", "Optional authentication token for inline mode")
@@ -75,12 +74,8 @@ func main() {
 	// inline mode
 	if *inlineMode {
 
-		if *inlineBaseURL == "" {
-			fmt.Println("Error: Base URL (--url) is required in inline mode.")
-			return
-		}
-		if *inlineEndpoint == "" {
-			fmt.Println("Error: Endpoint (--endpoint) is required in inline mode.")
+		if *inlineURL == "" {
+			fmt.Println("Error: URL (--url) is required in inline mode.")
 			return
 		}
 
@@ -104,9 +99,8 @@ func main() {
 		inlineOpts := inline.Options{
 			Method:             *inlineMethod,
 			Body:               *inlineBody,
-			Endpoint:           *inlineEndpoint,
+			URL:                *inlineURL,
 			Headers:            headers,
-			BaseURL:            *inlineBaseURL,
 			Protocol:           *inlineProtocol,
 			Timeout:            *inlineTimeout,
 			Token:              *inlineToken,


### PR DESCRIPTION
This PR combines the `BaseURL` and `Endpoint` in inline mode to be taken from a single flag (`--url`).